### PR TITLE
add Paul Seyfert (CERN) to contributors/authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@
 # Please keep the list sorted.
 
 Bastian Wieck <b.wieck@gmx.de>
+CERN
 David Blyth <dblyth@anl.gov>
 Emmanuel Busato <busato@in2p3.fr>
 Michaël Ughetto <mughetto@cern.ch>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,5 +20,6 @@ David Blyth <dblyth@anl.gov>
 Emmanuel Busato <busato@in2p3.fr>
 Michaël Ughetto <mughetto@cern.ch>
 Mohamed Amine Elgnaoui <mohamed.amine.elgnaoui@gmail.com>
+Paul Seyfert <Paul.Seyfert@cern.ch>
 Peter Waller <p@pwaller.net>
 Sebastien Binet <binet@cern.ch>


### PR DESCRIPTION
Seems the small change https://github.com/go-hep/hep/pull/347 brings CERN to the copyright holders … atm I sorted the organization name alphabetically into the names. 